### PR TITLE
Replace b tags with strong

### DIFF
--- a/wp-print.php
+++ b/wp-print.php
@@ -220,9 +220,9 @@ function print_content($display = true) {
 				$content = str_replace_one($link_match, "<a href=\"$link_url\" rel=\"external\">".$link_text.'</a> <sup>['.number_format_i18n($link_number).']</sup>', $content);
 				if ($new_link) {
 					if(preg_match('/<img(.+?)src=[\"\'](.+?)[\"\'](.*?)>/',$link_text)) {
-						$links_text .= '<p style="margin: 2px 0;">['.number_format_i18n($link_number).'] '.__('Image', 'wp-print').': <b><span dir="ltr">'.$link_url.'</span></b></p>';
+						$links_text .= '<p style="margin: 2px 0;">['.number_format_i18n($link_number).'] '.__('Image', 'wp-print').': <strong><span dir="ltr">'.$link_url.'</span></strong></p>';
 					} else {
-						$links_text .= '<p style="margin: 2px 0;">['.number_format_i18n($link_number).'] '.$link_text.': <b><span dir="ltr">'.$link_url.'</span></b></p>';
+						$links_text .= '<p style="margin: 2px 0;">['.number_format_i18n($link_number).'] '.$link_text.': <strong><span dir="ltr">'.$link_url.'</span></strong></p>';
 					}
 				}
 			}
@@ -285,9 +285,9 @@ function print_comments_content($display = true) {
 			$content = str_replace_one($link_match, "<a href=\"$link_url\" rel=\"external\">".$link_text.'</a> <sup>['.number_format_i18n($link_number).']</sup>', $content);
 			if ($new_link) {
 				if(preg_match('/<img(.+?)src=[\"\'](.+?)[\"\'](.*?)>/',$link_text)) {
-					$links_text .= '<p style="margin: 2px 0;">['.number_format_i18n($link_number).'] '.__('Image', 'wp-print').': <b><span dir="ltr">'.$link_url.'</span></b></p>';
+					$links_text .= '<p style="margin: 2px 0;">['.number_format_i18n($link_number).'] '.__('Image', 'wp-print').': <strong><span dir="ltr">'.$link_url.'</span></strong></p>';
 				} else {
-					$links_text .= '<p style="margin: 2px 0;">['.number_format_i18n($link_number).'] '.$link_text.': <b><span dir="ltr">'.$link_url.'</span></b></p>';
+					$links_text .= '<p style="margin: 2px 0;">['.number_format_i18n($link_number).'] '.$link_text.': <strong><span dir="ltr">'.$link_url.'</span></strong></p>';
 				}
 			}
 		}


### PR DESCRIPTION
Our accessibility testing tool is reporting the following issue: `C22: Use 'em' or 'strong', or stylesheets, instead of 'b'`

https://www.w3.org/WAI/WCAG21/Techniques/css/C22

This PR replaces usage of `<b>` tags with `<strong>` tags to help mitigate this issue. 

Thank you for this plugin! 